### PR TITLE
Continue the rework of the Tutorial part. Still unfinished.

### DIFF
--- a/manuscript/manuscript.tex
+++ b/manuscript/manuscript.tex
@@ -971,10 +971,10 @@ The expected results are summarized in Table~\ref{tab_dg_monomers_dimer}.
 		\toprule
 		System       & E(internal) & $\Delta E^\textit{GIST}$ & $\Delta S^\textit{GIST}$ & $\Delta S^\textit{scaled}$ & total \\
 		\midrule
-		complex      & -1303.4 & -361.2 & -233.1 & -139.9 & -192.0 \\
-		streptavidin & -1180.7 & -360.8 & -242.4 & -145.4 & -188.4 \\
-		biotin       & -24.0   &  -98.1 &  -35.1 &  -21.1 & -105.4 \\
-		Diff         & -98.7   &   97.7 &   44.4 &   26.6 &  -27.6 \\
+		complex      & -1303.4 & -361.2 & -233.1 & -139.9 & -1524.7 \\
+		streptavidin & -1180.7 & -360.8 & -242.4 & -145.4 & -1396.1 \\
+		biotin       & -24.0   &  -98.1 &  -35.1 &  -21.1 &  -101.0 \\
+		Diff         & -98.7   &   97.7 &   44.4 &   26.6 &   -27.6 \\
 		\bottomrule
 	\end{tabular}
 \end{table}


### PR DESCRIPTION
I started to update the tutorial part. I removed (commented out) the list of options to cpptraj. The current version was incomplete. We can include it, but then it should be complete, and I'd rather not have it in the main text because it will be very long. What do you think of a "Cheatsheet" page summarizing all options, output columns, and a few equations?

I also removed a lot of `\todo` tags.