### PR TITLE
Correct Eww_ref calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![A image showing a thermodynamic solvent densitie around a carbazole molecule](./releases/header_v1.0.png "Grid Inhomogenous Solvation Theory - GIST")
+
 # GIST-Tutorial
+
 A tutorial for Grid Inhomogenous Solvation Theory (GIST) as implemented in AmberTool's cpptraj.
 The tutorial aims to teach how to apply GIST for small molecules and proteins, with biotin-streptavidin as a showcase example.
 
@@ -9,6 +11,7 @@ The tutorial is developed in line with LiveCoMS guidelines on [Paper Writing as 
 If you notice any issues or have suggestions, please raise them as an [Issue](https://github.com/liedllab/gist-tutorial/issues) or write up a [Pull Request](https://github.com/liedllab/gist-tutorial/pulls).
 
 # Repository Content
+
 This repository contains the following folders and files:
 - [code](https://github.com/liedllab/gist-tutorial/tree/main/code): Input files and scripts to run the Biotin/Streptavidin example shown in the manuscript.
 - [manuscript](https://github.com/liedllab/gist-tutorial/tree/main/manuscript): LaTeX files for the manuscript and bibliography.
@@ -42,7 +45,9 @@ The tutorial code is provided as a Jupyter Notebook at `code/tutorial-gist.ipynb
 We recommend using [JupyterLab](https://jupyter.org/) or [VS Code](https://code.visualstudio.com/) (with the Jupyter extensions) for editing and working with the notebook.
 
 Molecular visualisations are generated with [PyMol](https://pymol.org/) and input scripts are provided in the `output/visualization` folder.
+
 # Authors
+
 In the same order as in the manuscript:
 * Valentin J. Egger-Hoerschinger
 * Franz Waibl
@@ -58,6 +63,7 @@ In the same order as in the manuscript:
 The repository is currently managed by Valentin ([@vhoer](https://www.github.com/vhoer)).
 
 # Citation
+
 ```
 @article{EggerHoerschinger2025,
 author = {Egger-Hoerschinger, Valentin J. and Waibl, Franz and Molino, Vjay and Carter, Helmut and Fernández-Quintero, Monica L. and Ramsey, Steven and Roe, Daniel R. and Liedl, Klaus R. and Gilson, Michael K. and Kurtzman, Tom},
@@ -70,3 +76,12 @@ year = {2025},
 doi = {11.33011/livecoms.6.1.3059},
 }
 ```
+
+# Changelog
+
+The following changes were made after the LiveCoMS version (v1.0):
+
+## v1.1
+* Corrected $`E_{ww, norm}`$ calculation for solvents other than water in section 'Running GIST'
+
+

--- a/manuscript/manuscript.tex
+++ b/manuscript/manuscript.tex
@@ -47,7 +47,7 @@
 %%% IMPORTANT USER CONFIGURATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\newcommand{\versionnumber}{1.0}  % you should update the minor version number in preprints and major version number of submissions.
+\newcommand{\versionnumber}{1.1}  % you should update the minor version number in preprints and major version number of submissions.
 \newcommand{\githubrepository}{\url{https://github.com/liedllab/gist-tutorial}}  %this should be the main github repository for this article
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -384,13 +384,15 @@ The water boxes were prepared with \software{tleap} to a size of \qty{100}{\angs
 
 Because of the different sizes of the boxes, the reference energies used in this tutorial may not align with those specified in the Amber manual. 
 In general, it is advisable to conduct your own reference calculations, especially for systems that are either very large or very small. 
-The reference values can be extracted from unrestrained MD trajectories of pure bulk solvent by calculating the average potential energy per solvent molecule ($E_{ww, norm}$) and the average solvent density $\rho_0$:
+The reference values can be extracted from unrestrained MD trajectories of pure bulk solvent by calculating the average interaction energy per solvent molecule ($E_{ww, norm}$) and the average solvent density $\rho_0$:
 \begin{equation}
-	E_{ww, norm} = \frac{\bar{E}_{pot,\ total}}{N_{WAT}}
+	E_{ww, norm} = \frac{\bar{E}_{NB,\ total}}{N_{WAT}}
 \end{equation}	
 \begin{equation}
 	\rho_0 = \frac{N_{WAT}}{\bar{V}_{box}}
 \end{equation}
+where $\bar{E}_{NB,\ total}$ is the average inter-molecule, non-bonded energy of all solvent molecules, $N_{WAT}$ is the number of solvent molecules, and $\bar{V}_{box}$ is the average volume of the simulation box.
+Note that $\bar{E}_{NB,\ total}$ might be a sum of various other energy terms, depending on the force field and simulation engine used. For AMBER, this includes van der Waals (VDWAALS) and electrostatic interactions (EELEC).
 It is recommended that the size of the reference solvent box closely matches that of the production system.
 While the impact on the density is not as pronounced, deviations from the production settings can lead to differences of up to 0.005 kcal/mol in the energy per solvent molecule ($E_{ww, norm}$) for water boxes. 
 These discrepancies, when summing over large grid regions, have the potential to introduce significant errors due to incorrect referencing.

--- a/manuscript/manuscript.tex
+++ b/manuscript/manuscript.tex
@@ -394,6 +394,8 @@ The reference values can be extracted from unrestrained MD trajectories of pure 
 where $\bar{E}_{NB,\ total}$ is the average inter-molecule, non-bonded energy of all solvent molecules, $N_{WAT}$ is the number of solvent molecules, and $\bar{V}_{box}$ is the average volume of the simulation box.
 Note that $\bar{E}_{NB,\ total}$ might be a sum of various other energy terms, depending on the force field and simulation engine used. For AMBER, this includes van der Waals (VDWAALS) and electrostatic interactions (EELEC).
 It is recommended that the size of the reference solvent box closely matches that of the production system.
+To align more closely with GISTs energy calculation, $E_{ww, norm}$ can also be calculated by running a GIST calculation on the bulk solvent box and averaging over all inner voxels (i.e. not on the grid border). 
+This approach is advisible when not using PME GIST or using simulation engines different from AMBER, as the energy calculation might then be different between GIST and the simulation.
 While the impact on the density is not as pronounced, deviations from the production settings can lead to differences of up to 0.005 kcal/mol in the energy per solvent molecule ($E_{ww, norm}$) for water boxes. 
 These discrepancies, when summing over large grid regions, have the potential to introduce significant errors due to incorrect referencing.
 


### PR DESCRIPTION
The previous approach (E_pot / Nwat from the simulation) was only correct for water models in AMBER and only when using GIST PME. 
Now, the calculation instead uses E_NB, which I define as the average inter-molecular energy. 
Additionally, a GIST based approach is introduced, i.e. run a GIST calculation for the reference simulation and average over all non-border voxels.